### PR TITLE
add tests

### DIFF
--- a/tests/components/tado/test_service.py
+++ b/tests/components/tado/test_service.py
@@ -1,8 +1,21 @@
 """The serive tests for the tado platform."""
-from homeassistant.components.tado.const import DOMAIN, SERVICE_ADD_METER_READING
+import json
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components.tado.const import (
+    ATTR_CONFIG_ENTRY,
+    ATTR_READING,
+    DOMAIN,
+    SERVICE_ADD_METER_READING,
+)
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
 
 from .util import async_init_integration
+
+from tests.common import MockConfigEntry, load_fixture
 
 
 async def test_has_services(
@@ -13,3 +26,107 @@ async def test_has_services(
     await async_init_integration(hass)
 
     assert hass.services.has_service(DOMAIN, SERVICE_ADD_METER_READING)
+
+
+async def test_add_meter_readings(
+    hass: HomeAssistant,
+) -> None:
+    """Test the add meter reading service."""
+
+    await async_init_integration(hass)
+
+    config_entry: MockConfigEntry = hass.config_entries.async_entries(DOMAIN)[0]
+    fixture: str = load_fixture("tado/add_readings_success.json")
+    with patch(
+        "homeassistant.components.tado.TadoConnector.set_meter_reading",
+        return_value=json.loads(fixture),
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_ADD_METER_READING,
+            service_data={
+                ATTR_CONFIG_ENTRY: config_entry.entry_id,
+                ATTR_READING: 1234,
+            },
+            blocking=True,
+        )
+
+
+async def test_add_meter_readings_exception(
+    hass: HomeAssistant,
+) -> None:
+    """Test the add meter reading service."""
+
+    await async_init_integration(hass)
+
+    config_entry: MockConfigEntry = hass.config_entries.async_entries(DOMAIN)[0]
+    with (
+        patch(
+            "homeassistant.components.tado.TadoConnector.set_meter_reading",
+            return_value=None,
+        ),
+        pytest.raises(ServiceValidationError),
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_ADD_METER_READING,
+            service_data={
+                ATTR_CONFIG_ENTRY: config_entry.entry_id,
+                ATTR_READING: 1234,
+            },
+            blocking=True,
+        )
+
+
+async def test_add_meter_readings_invalid(
+    hass: HomeAssistant,
+) -> None:
+    """Test the add meter reading service."""
+
+    await async_init_integration(hass)
+
+    config_entry: MockConfigEntry = hass.config_entries.async_entries(DOMAIN)[0]
+    fixture: str = load_fixture("tado/add_readings_invalid_meter_reading.json")
+    with (
+        patch(
+            "homeassistant.components.tado.TadoConnector.set_meter_reading",
+            return_value=json.loads(fixture),
+        ),
+        pytest.raises(ServiceValidationError),
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_ADD_METER_READING,
+            service_data={
+                ATTR_CONFIG_ENTRY: config_entry.entry_id,
+                ATTR_READING: 1234,
+            },
+            blocking=True,
+        )
+
+
+async def test_add_meter_readings_duplicate(
+    hass: HomeAssistant,
+) -> None:
+    """Test the add meter reading service."""
+
+    await async_init_integration(hass)
+
+    config_entry: MockConfigEntry = hass.config_entries.async_entries(DOMAIN)[0]
+    fixture: str = load_fixture("tado/add_readings_duplicated_meter_reading.json")
+    with (
+        patch(
+            "homeassistant.components.tado.TadoConnector.set_meter_reading",
+            return_value=json.loads(fixture),
+        ),
+        pytest.raises(ServiceValidationError),
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_ADD_METER_READING,
+            service_data={
+                ATTR_CONFIG_ENTRY: config_entry.entry_id,
+                ATTR_READING: 1234,
+            },
+            blocking=True,
+        )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add tests for add_meter_readings

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

100% code coverage

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
